### PR TITLE
Added `amd` property according to AMD specs

### DIFF
--- a/source/lamd.js
+++ b/source/lamd.js
@@ -87,6 +87,11 @@ var lamd = {};
 	lib.define = define;
 	lib.require = require;
 
+	// AMD standard requires a define.amd property
+	// available in the define object
+	// https://github.com/amdjs/amdjs-api/wiki/AMD
+	lib.define.amd = {};
+
 })(lamd);
 
 if (typeof require === "undefined") {

--- a/tests/specs/defineTests.js
+++ b/tests/specs/defineTests.js
@@ -22,4 +22,9 @@ describe("define", function() {
 		lamd.define("test/3", 40);
 	});
 
+	it("has `amd` property", function() {
+		expect(!!lamd.define.amd).toBe(true);
+		expect(typeof lamd.define.amd).toBe("object");
+	});
+
 });


### PR DESCRIPTION
[AMD specs](https://github.com/amdjs/amdjs-api/wiki/AMD#defineamd-property-) requires `amd` property to be available on `define`.
