### PR TITLE
Timeout export issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lamd",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Local Asynchronous Module Definition library",
   "main": "source/lamd.js",
   "scripts": {

--- a/source/lamd+timeout.js
+++ b/source/lamd+timeout.js
@@ -48,6 +48,8 @@
 		}
 		__define.apply(undefined, arguments);
 	};
+	
+	lamd.define.amd = __define.amd;
 
 	lamd.require = function() {
 		var requirements = arguments[0];


### PR DESCRIPTION
Adds back `define.amd` in debug version of the library.
